### PR TITLE
Update dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins
+FROM jenkins/jenkins
 USER root
 
 RUN mkdir -p /tmp/download && \


### PR DESCRIPTION
Earlier in the course when getting jenkins from docker using `jenkins` a lot of the plug-ins were failing. 

I saw that you mentioned that `jenkins/jenkins` was the latest and mentioned [the docker hub page](https://hub.docker.com/r/jenkins/jenkins/)

Once I used `jenkins/jenkins` everything worked, however when building the new docker container of `jenkins-docker` the jenkins webapp crashed. 

It wasn't until I edited the dockerfile and rebuilt the container that functionality was restored.  

Figured I'd request the pull to help future students. 