### PR TITLE
Use LTS version of Jenkins; upgrade Docker to 18.0.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM jenkins/jenkins
+FROM jenkins/jenkins:lts
 USER root
 
 RUN mkdir -p /tmp/download && \
- curl -L https://download.docker.com/linux/static/stable/x86_64/docker-18.03.1-ce.tgz | tar -xz -C /tmp/download && \
+ curl -L https://download.docker.com/linux/static/stable/x86_64/docker-18.06.1-ce.tgz | tar -xz -C /tmp/download && \
  rm -rf /tmp/download/docker/dockerd && \
  mv /tmp/download/docker/docker* /usr/local/bin/ && \
  rm -rf /tmp/download && \


### PR DESCRIPTION
It's possible that there could be issues with using the weekly build of Jenkins.  Why LTS isn't the default, I have no idea.

Also, since 18.0.6.1 of Docker has been out since August of 2018, it's probably safe to use 18.0.6 instead of 18.0.3.